### PR TITLE
Initial implementation ideas for Segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "uuid",
  "yaml-rust",
 ]
 
@@ -1591,6 +1592,16 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "uuid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+dependencies = [
+ "getrandom",
+ "rand",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1.2"
 futures = "0.3"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "1.2", features = ["v4", "fast-rng"] }
 
 [dependencies.tokio-postgres]
 git = "https://github.com/MaterializeInc/rust-postgres.git"

--- a/src/events/cache.rs
+++ b/src/events/cache.rs
@@ -1,0 +1,19 @@
+use crate::events::Values;
+
+#[derive(Debug)]
+pub(crate) struct Cache(Vec<Values>);
+
+impl Cache {
+    pub(crate) fn new() -> Cache {
+        Cache(Vec::new())
+    }
+
+    pub(crate) fn add(&mut self, values: Values) {
+        self.0.push(values);
+        println!("Cache size {:?}", self.0.len());
+    }
+
+    pub(crate) fn full(&self) -> bool {
+        self.0.len() >= 1_000
+    }
+}

--- a/src/events/collection.rs
+++ b/src/events/collection.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+use tokio::sync::mpsc::Sender;
+use yaml_rust::Yaml;
+
+use crate::events::{self, errors::Error, schema::Schema, segment, terminator};
+
+pub(crate) struct Collection {
+    schemas: HashMap<String, Schema>,
+    terminator: terminator::Terminator,
+    expiration: Sender<events::Event>,
+}
+
+// Return a new Collection configured with the given config.
+//
+// The Collection is responsible to monitor different indices
+// that intake will ingest. Each index will have an entry in the collection
+// connecting the Schema and the ongoing Segment together.
+pub(crate) fn new(_config: &Yaml, expiration_sender: Sender<events::Event>) -> Collection {
+    Collection {
+        schemas: HashMap::new(),
+        expiration: expiration_sender,
+        terminator: terminator::new(),
+    }
+}
+
+// Public
+impl Collection {
+    pub(crate) fn insert(&mut self, index: &str, data: crate::events::Values) -> Result<(), Error> {
+        match self.schemas.get_mut(index) {
+            Some(schema) => {
+                if let Some(seg) = schema.segment() {
+                    println!("Adding data to existing segment: {}", &seg.uuid);
+                    seg.add(data)?
+                } else {
+                    let mut seg = segment::new(&schema, self.expiration.clone());
+                    println!("Creating new segment for existing schema: {}", &seg.uuid);
+                    seg.add(data)?;
+                    *schema.segment() = Some(seg);
+                }
+            }
+            None => {
+                println!("Creating new entry for index: {}", &index);
+                let mut schema = Schema::try_from((index, &data))?;
+                *schema.segment() = Some(segment::new(&schema, self.expiration.clone()));
+                self.schemas.insert(schema.name(), schema.into());
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn expired(&mut self, index: &str, id: &uuid::Uuid) {
+        if let Some(schema) = self.schemas.get_mut(index) {
+            if let Some(seg) = schema.segment().take() {
+                self.terminator.terminate(seg);
+            }
+        }
+    }
+}

--- a/src/events/errors.rs
+++ b/src/events/errors.rs
@@ -1,0 +1,11 @@
+#[derive(Debug)]
+pub(crate) enum Error {
+    ParquetError(String),
+    FileError(String),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::FileError(e.to_string())
+    }
+}

--- a/src/events/schema.rs
+++ b/src/events/schema.rs
@@ -1,0 +1,80 @@
+use crate::events::segment::Segment;
+use crate::events::Values;
+use parquet::file::properties::WriterPropertiesPtr;
+use parquet::schema::types::TypePtr;
+use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
+
+#[derive(Debug)]
+pub(crate) struct Schema {
+    segment: Option<Segment>,
+
+    name: String,
+    types: TypePtr,
+    properties: WriterPropertiesPtr,
+}
+
+impl PartialEq for Schema {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Hash for Schema {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl Eq for Schema {}
+
+impl Borrow<String> for Schema {
+    fn borrow(&self) -> &String {
+        &self.name
+    }
+}
+
+impl Borrow<str> for Schema {
+    fn borrow(&self) -> &str {
+        &self.name
+    }
+}
+
+impl TryFrom<(&str, &Values)> for Schema {
+    type Error = crate::events::errors::Error;
+
+    fn try_from(tuple: (&str, &Values)) -> Result<Self, Self::Error> {
+        use parquet::file::properties::WriterProperties;
+        use parquet::schema::types::Type;
+
+        let properties = WriterProperties::builder().build();
+        let definition = Type::group_type_builder(tuple.0).build()?;
+
+        Ok(Schema {
+            name: tuple.0.to_owned(),
+            types: TypePtr::new(definition),
+            properties: WriterPropertiesPtr::new(properties),
+            segment: None,
+        })
+    }
+}
+
+impl Schema {
+    #[inline]
+    pub(crate) fn types(&self) -> TypePtr {
+        self.types.clone()
+    }
+
+    #[inline]
+    pub(crate) fn properties(&self) -> WriterPropertiesPtr {
+        self.properties.clone()
+    }
+
+    pub(crate) fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub(crate) fn segment(&mut self) -> &mut Option<Segment> {
+        &mut self.segment
+    }
+}

--- a/src/events/segment.rs
+++ b/src/events/segment.rs
@@ -1,0 +1,65 @@
+use crate::events::{self, cache::Cache, errors::Error, schema::Schema};
+use parquet::errors::ParquetError;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::format::FileMetaData;
+use tokio::sync::mpsc::Sender;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub(crate) struct Segment {
+    pub uuid: Uuid,
+    cache: Cache,
+}
+
+impl From<ParquetError> for Error {
+    fn from(e: ParquetError) -> Self {
+        Self::ParquetError(e.to_string())
+    }
+}
+
+pub(crate) fn new(schema: &Schema, expiration: Sender<events::Event>) -> Segment {
+    use std::time::Duration;
+
+    let segment = Segment {
+        uuid: Uuid::new_v4(),
+        cache: Cache::new(),
+    };
+
+    let name = schema.name().to_owned();
+    let uuid = segment.uuid;
+
+    tokio::task::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        if let Err(e) = expiration
+            .send(events::Event::SegmentExpired(name, uuid))
+            .await
+        {
+            panic!("Could not send expiration event: {:?}", e);
+        }
+    });
+
+    segment
+}
+
+impl Segment {
+    // closes the Segment
+    pub(crate) fn close(&mut self, schema: &Schema) -> Result<FileMetaData, Error> {
+        use std::fs::File;
+        use std::path::Path;
+
+        let filename = format!("./{}.parquet", self.uuid.as_hyphenated().to_string());
+        let path = Path::new(&filename);
+        let file = File::create(&path)?;
+        let writer = SerializedFileWriter::new(file, schema.types(), schema.properties())?;
+
+        Ok(writer.close()?)
+    }
+
+    pub(crate) fn upload(&mut self) {}
+
+    pub(crate) fn add(&mut self, values: events::Values) -> Result<(), Error> {
+        self.cache.add(values);
+        Ok(())
+    }
+}

--- a/src/events/terminator.rs
+++ b/src/events/terminator.rs
@@ -1,0 +1,19 @@
+use crate::events::segment::Segment;
+
+// Terminator is responsible to close Segments that are
+// either full or that the timer reached its limit
+// It consumes the option from the Segment's collection
+// so that the option is set to None ready to be initialized again
+// when a new event for that index reaches intake.
+
+pub(crate) struct Terminator(Option<Box<dyn crate::storage::Expeditor + Send>>);
+
+pub(crate) fn new() -> Terminator {
+    Terminator(None)
+}
+
+impl Terminator {
+    pub(crate) fn terminate(&self, segment: Segment) {
+        println!("Terminating the segment: {:?}", &segment);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,12 @@ async fn main() {
     if config.len() != 1 {
         panic!("YAML configuration requires the file to contain exactly 1 top level object(found: {} top level objects).", config.len());
     }
+    let config = &config[0];
 
-    let sender = events::listen();
+    let sender = events::listen(config);
 
     loop {
-        let (mut src, failure) = source::initialize(&config[0]["source"]).await.unwrap();
+        let (mut src, failure) = source::initialize(&config["source"]).await.unwrap();
 
         // Cloning is needed here for the sender because the loop will re-execute and
         // the sender will be moved after the first iteration.

--- a/src/source/postgresql/event.rs
+++ b/src/source/postgresql/event.rs
@@ -5,9 +5,7 @@ use serde_json::Value as JSONValue;
 
 pub(crate) fn from_json(payload: &[u8]) -> Result<Vec<Event>, Error> {
     let mutations: Mutations = serde_json::from_slice(payload)?;
-    let events = mutations.mutations.into_iter().collect();
-
-    Ok(events)
+    Ok(mutations.mutations.into_iter().collect())
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -15,6 +13,7 @@ struct Mutations {
     #[serde(rename = "change")]
     mutations: Vec<Mutation>,
 }
+
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(tag = "kind")]
 #[serde(rename_all = "camelCase")]
@@ -45,7 +44,7 @@ impl From<Mutation> for Event {
                 for (i, column) in columns.into_iter().enumerate() {
                     map.insert(column, Value::from((&types[i], &values[i])));
                 }
-                Event::Insert(map)
+                Event::Insert("test".into(), map)
             }
             _ => Self::default(),
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,3 +2,5 @@
 // to cloud storage (S3, Google Cloud, Minio, etc.)
 //
 // Its main focus is downloading and uploading files as requested by other sub-system.
+
+pub(crate) trait Expeditor {}


### PR DESCRIPTION
Segments are going to be parquet file that will serve as staging ground for in-flight data. This means that ingesting replication stream with intake won't commit data as transaction wraps, simply because it would defeat the purpose of an OLAP/parquet workload.

The Segment holds a cache in memory of all the events to be then compiled into a parquet format. This current implementation is highly inefficicent just because it is storing a vec of Values (BTreeMap<String, Value>) and that would mean the row to column transformation would be completely inefficient. This is an acceptable tradeoff because right now the goal is just to get intake to move OLTP data into an OLAP format. Performances adjustment are going to follow once the basic implementations are covered.