### PR TITLE
Schema: Infer types based on event

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -48,6 +48,16 @@ impl Default for Value {
     }
 }
 
+impl From<&Value> for parquet::basic::Type {
+    fn from(v: &Value) -> Self {
+        match v {
+            Value::Int64(_) => Self::INT64,
+            Value::Float(_) => Self::FLOAT,
+            Value::String(_) => Self::BYTE_ARRAY,
+        }
+    }
+}
+
 pub fn listen(config: &Yaml) -> mpsc::Sender<Event> {
     let (sender, mut receiver) = mpsc::channel(10);
     let mut segments = collection::new(config, sender.clone());


### PR DESCRIPTION
When receiving event for an index that was not present before, inference needs to occur to build a schema for the given event.

Currently, the schema is very naive, but at the very least it's supporting all basic physical properties.